### PR TITLE
Fix: Non-api urls going via server's cookie middleware, Cookie tampering, API blocking

### DIFF
--- a/src/client/components/AddDocumentPage/AddDocumentPage.js
+++ b/src/client/components/AddDocumentPage/AddDocumentPage.js
@@ -56,7 +56,7 @@ const AddDocumentPage = (props) => {
 				// const mutatedNewService = mutateNewServiceForDisplay(newService, vehicles, serviceableComponents);
 				// setNewService( mutatedNewService )
 			}else{
-				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WROING);
+				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WRONG);
 			}
 		});
 	}

--- a/src/client/components/AddServicePage/AddServicePage.js
+++ b/src/client/components/AddServicePage/AddServicePage.js
@@ -66,7 +66,7 @@ const AddServicePage = (props) => {
 				clear();
 				setNewService( mutatedNewService );
 			}else{
-				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WROING);
+				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WRONG);
 			}
 		});
 	}

--- a/src/client/components/AddVehiclePage/AddVehiclePage.js
+++ b/src/client/components/AddVehiclePage/AddVehiclePage.js
@@ -38,7 +38,7 @@ const AddVehiclePage = (props) => {
 			if( status == ApiConstants.STATUS_SUCCESS ){
 				props.history.push(getRouteDetailsFromKey(routeConstants.ADD_SERVICE).path);
 			}else{
-				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WROING);
+				dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WRONG);
 			}
 		});
 	}

--- a/src/client/constants/ApiConstants.js
+++ b/src/client/constants/ApiConstants.js
@@ -1,4 +1,5 @@
 export default {
     STATUS_SUCCESS: "success",
-    STATUS_ERROR: "error"
+    STATUS_ERROR: "error",
+    UNAUTHORIZED: 401
 }

--- a/src/client/constants/StringConstants.js
+++ b/src/client/constants/StringConstants.js
@@ -10,7 +10,7 @@ export default {
         INVALID_DETAILS: "Empty/Incorrect details entered. Please verify the details entered.",
         PASSWORD_MATCH_ERROR: "Passwords do not match. Please re-enter.",
         VEHICLE_ADD_SUCCESS: "Your vehicle is added successfully. Start adding services.",
-        SOMETHING_WENT_WROING: "Something went wrong. Please try again.",
+        SOMETHING_WENT_WRONG: "Something went wrong. Please try again.",
         COOKIE_NOT_FOUND: "We've forcefully logged you out because of invalid credentials. Please login again!"
     },
 

--- a/src/client/constants/StringConstants.js
+++ b/src/client/constants/StringConstants.js
@@ -10,7 +10,8 @@ export default {
         INVALID_DETAILS: "Empty/Incorrect details entered. Please verify the details entered.",
         PASSWORD_MATCH_ERROR: "Passwords do not match. Please re-enter.",
         VEHICLE_ADD_SUCCESS: "Your vehicle is added successfully. Start adding services.",
-        SOMETHING_WENT_WROING: "Something went wrong. Please try again."
+        SOMETHING_WENT_WROING: "Something went wrong. Please try again.",
+        COOKIE_NOT_FOUND: "We've forcefully logged you out because of invalid credentials. Please login again!"
     },
 
     CTA_TEXT: {

--- a/src/client/state/documents.js
+++ b/src/client/state/documents.js
@@ -9,12 +9,24 @@ const documents = store => {
     store.on('documents/get', async (state, user)=>{
         store.dispatch('loading:true');
         const documents = await makeApiCall("/api/users/" + user + "/documents", { method: 'GET' });
+        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+            store.dispatch('documents/get:error');
+            store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
+            store.dispatch('user/clear');
+            return;
+        }
         store.dispatch('documents/get:success', documents.data);
     });
 
     store.on('documents/vehicle/get', async (state, vehicle)=>{
         store.dispatch('loading:true');
         const documents = await makeApiCall("/api/vehicles/" + vehicle + "/documents", { method: 'GET' });
+        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+            store.dispatch('documents/get:error');
+            store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
+            store.dispatch('user/clear');
+            return;
+        }
         store.dispatch('documents/get:success', documents.data);
     });
 

--- a/src/client/state/documents.js
+++ b/src/client/state/documents.js
@@ -9,25 +9,33 @@ const documents = store => {
     store.on('documents/get', async (state, user)=>{
         store.dispatch('loading:true');
         const documents = await makeApiCall("/api/users/" + user + "/documents", { method: 'GET' });
-        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+
+        if( documents.status === ApiConstants.STATUS_SUCCESS ){
+            store.dispatch('documents/get:success', documents.data);
+        }else if( documents.status === ApiConstants.UNAUTHORIZED ){
             store.dispatch('documents/get:error');
             store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
             store.dispatch('user/clear');
-            return;
+        }else{
+            store.dispatch('documents/get:error');
+            store.dispatch('snackbar:show', documents.message);
         }
-        store.dispatch('documents/get:success', documents.data);
     });
 
     store.on('documents/vehicle/get', async (state, vehicle)=>{
         store.dispatch('loading:true');
         const documents = await makeApiCall("/api/vehicles/" + vehicle + "/documents", { method: 'GET' });
-        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+
+        if( documents.status === ApiConstants.STATUS_SUCCESS ){
+            store.dispatch('documents/get:success', documents.data);
+        }else if( documents.status === ApiConstants.UNAUTHORIZED ){
             store.dispatch('documents/get:error');
             store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
             store.dispatch('user/clear');
-            return;
+        }else{
+            store.dispatch('documents/get:error');
+            store.dispatch('snackbar:show', documents.message);
         }
-        store.dispatch('documents/get:success', documents.data);
     });
 
     store.on('documents/get:success', (state, data)=>{

--- a/src/client/state/services.js
+++ b/src/client/state/services.js
@@ -9,13 +9,17 @@ const services = store => {
     store.on('services/get', async (state, vehicle)=>{
         store.dispatch('loading:true');
         const services = await makeApiCall("/api/vehicles/" + vehicle + "/services", { method: 'GET' });
-        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+
+        if( services.status === ApiConstants.STATUS_SUCCESS ){
+            store.dispatch('services/get:success', services.data);
+        }else if( services.status === ApiConstants.UNAUTHORIZED ){
             store.dispatch('services/get:error');
             store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
             store.dispatch('user/clear');
-            return;
+        }else{
+            store.dispatch('services/get:error');
+            store.dispatch('snackbar:show', services.message);
         }
-        store.dispatch('services/get:success', services.data);
     });
 
     store.on('services/get:success', (state, data)=>{
@@ -26,7 +30,6 @@ const services = store => {
     //TODO:: This is not being used. Fix!
     store.on('services/get:error', (state, error)=>{
         store.dispatch('loading:false');
-        console.log('Error in fetching services', error);
         return { services: [] };
     });
 

--- a/src/client/state/services.js
+++ b/src/client/state/services.js
@@ -9,6 +9,12 @@ const services = store => {
     store.on('services/get', async (state, vehicle)=>{
         store.dispatch('loading:true');
         const services = await makeApiCall("/api/vehicles/" + vehicle + "/services", { method: 'GET' });
+        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+            store.dispatch('services/get:error');
+            store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
+            store.dispatch('user/clear');
+            return;
+        }
         store.dispatch('services/get:success', services.data);
     });
 

--- a/src/client/state/user.js
+++ b/src/client/state/user.js
@@ -11,6 +11,7 @@ const user = store => {
     store.on('user/signup', async (state, userDetails)=>{
         store.dispatch('loading:true');
         const result = await makeApiCall("/api/signup", { method: 'POST', body: {userDetails} });
+        
         if( result.status === ApiConstants.STATUS_SUCCESS ){
             store.dispatch('user/signup:success', result.data);
         }else{

--- a/src/client/state/user.js
+++ b/src/client/state/user.js
@@ -5,6 +5,8 @@ import ApiConstants from "../constants/ApiConstants";
 const user = store => {
     store.on('@init', ()=>({ user: {isLoggedIn: false} }));
 
+    store.on('user/clear', ()=>({ user: {isLoggedIn: false} }));
+
     /* Signup flow */
     store.on('user/signup', async (state, userDetails)=>{
         store.dispatch('loading:true');

--- a/src/client/state/vehicles.js
+++ b/src/client/state/vehicles.js
@@ -8,13 +8,17 @@ const vehicles = store => {
     store.on('vehicles/get', async (state, user)=>{
         store.dispatch('loading:true');
         const vehicles = await makeApiCall("/api/users/" + user + "/vehicles", { method: 'GET' });
-        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+
+        if( vehicles.status === ApiConstants.STATUS_SUCCESS ){
+            store.dispatch('vehicles/get:success', vehicles.data);
+        }else if( vehicles.status === ApiConstants.UNAUTHORIZED ){
             store.dispatch('vehicles/get:error');
             store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
             store.dispatch('user/clear');
-            return;
+        }else{
+            store.dispatch('vehicles/get:error');
+            store.dispatch('snackbar:show', vehicles.message);
         }
-        store.dispatch('vehicles/get:success', vehicles.data);
     });
 
     store.on('vehicles/get:success', (state, data)=>{
@@ -24,7 +28,6 @@ const vehicles = store => {
 
     store.on('vehicles/get:error', (state, error)=>{
         store.dispatch('loading:false');
-        console.log('Error in fetching vehicles', error);
         return { vehicles: [] };
     });
 

--- a/src/client/state/vehicles.js
+++ b/src/client/state/vehicles.js
@@ -8,6 +8,12 @@ const vehicles = store => {
     store.on('vehicles/get', async (state, user)=>{
         store.dispatch('loading:true');
         const vehicles = await makeApiCall("/api/users/" + user + "/vehicles", { method: 'GET' });
+        if( vehicles.status === ApiConstants.UNAUTHORIZED ){
+            store.dispatch('vehicles/get:error');
+            store.dispatch('snackbar:show', Strings.SNACKBAR_MESSAGES.COOKIE_NOT_FOUND);
+            store.dispatch('user/clear');
+            return;
+        }
         store.dispatch('vehicles/get:success', vehicles.data);
     });
 

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -1,5 +1,4 @@
 body{
-    font-family: "Roboto";
     margin: 0;
 }
 

--- a/src/client/utils/ApiHelper.js
+++ b/src/client/utils/ApiHelper.js
@@ -1,4 +1,6 @@
 import fetch from 'isomorphic-fetch';
+import ApiConstants from "../constants/ApiConstants";
+import Strings from "../constants/StringConstants";
 
 const defaultHeaders = {
     'Content-Type': 'application/json'
@@ -16,7 +18,8 @@ const makeApiCall = async (url, {method, headers, body}) => {
 		const jsonResponse = await apiResponse.json();
 		return jsonResponse;
 	}catch(error){
-		return error;
+		console.log(error)
+		return { status: ApiConstants.STATUS_ERROR, message: Strings.SNACKBAR_MESSAGES.SOMETHING_WENT_WRONG };
 	}
 }
 

--- a/src/server/helpers/middlewares.js
+++ b/src/server/helpers/middlewares.js
@@ -10,16 +10,19 @@ const setHeaders = (req, res, next) => {
 };
 
 const validateUserCookie = (req, res, next) => {
-    if( req.method == 'OPTIONS' || req.path == '/api/login' || req.path == '/api/signup' ){
-        next();
-        return;
+    if( ( req.path.includes('/api') && req.method == 'OPTIONS' ) 
+        || req.path == '/api/login' 
+        || req.path == '/api/signup' 
+        || !req.path.includes('/api') ){
+            next();
+            return;
     }
     const { cookies: { token } } = req;
 
     if( token ){
         jwt.verify(token, constants.JWT_PRIVATE_KEY, function(err, decodedToken){
             if( err ){
-                res.status(401).send('Unauthorized access');
+                res.status(401).send({ status: 401, message: 'Unauthorized access. Please login.' });
                 return;
             }
 
@@ -29,17 +32,17 @@ const validateUserCookie = (req, res, next) => {
                         next();
                         return;
                     }else{
-                        res.status(401).send('Unauthorized access. Please login.');
+                        res.status(401).send({ status: 401, message: 'Unauthorized access. Please login.' });
                     }
                 }).catch(error => {
-                    res.status(401).send('Unauthorized access. Please login.');
+                    res.status(401).send({ status: 401, message: 'Unauthorized access. Please login.' });
                 })
             }else{
-                res.status(401).send('Unauthorized access. Please login.');
+                res.status(401).send({ status: 401, message: 'Unauthorized access. Please login.' });
             }
         });
     }else{
-        res.status(401).send('Unauthorized access. Please login.');
+        res.status(401).send({ status: 401, message: 'Unauthorized access. Please login.' });
     }
 }
 

--- a/www/index.html
+++ b/www/index.html
@@ -1,5 +1,11 @@
 <html>
 	<head>
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
+		<style>
+			body {
+				font-family: 'Roboto', serif;
+			}
+		</style>
 		<script src="/bundle.js" ></script>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 	</head>


### PR DESCRIPTION
fixes #102, #104, #105  

Fix 1: Since both client and server are using the same server code, /login page was also going through the **validateUserCookie** _middleware_ check that was meant for /api urls only. Fixed it by having middleware check only /api endpoints. Any other url hit or /api with OPTIONS method gets bypassed from this check.

Fix 2: If cookie is manually modified or deleted, the subsequent api calls were failing because server responds with 401, and this was not handled. Now it is properly handled - in such cases, user state is flushed, forcing the user to re-login, which resets the cookie.

Fix 3: In cases where the api call fails and fetch throws error (say, api blocked, network doesnt exist), UX wasnt handled at all, resulting in JS error. Now, the corresponding state is set to its initial state and an error message is thrown via global notification snackbar.

Bonus fix #101 